### PR TITLE
Adds info box and remove payment information blocks

### DIFF
--- a/website_sale_skip_payment/__openerp__.py
+++ b/website_sale_skip_payment/__openerp__.py
@@ -17,5 +17,6 @@
     ],
     'data': [
         'views/website_sale_skip_payment.xml',
+        'views/website_sale_template.xml',
     ],
 }

--- a/website_sale_skip_payment/views/website_sale_template.xml
+++ b/website_sale_skip_payment/views/website_sale_template.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="confirmation" inherit_id="website_sale.confirmation">
+        <xpath expr="//div[@class='thanks_msg']//h2"
+               position="after">
+            <div class="alert alert-info" role="alert"
+                 t-if="not is_public_user">
+                Our team will check your order and send you payment
+                information soon.
+            </div>
+        </xpath>
+        <xpath expr="(//div[@class='oe_cart']//h3)[2]"
+               position="attributes">
+            <attribute name="t-if">
+                is_public_user
+            </attribute>
+        </xpath>
+        <xpath expr="(//div[@class='oe_cart']//table[@class='table'])[2]"
+               position="attributes">
+            <attribute name="t-if">
+                is_public_user
+            </attribute>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
It's worthless to have a payment information block since the order is not paid now:
![image](https://user-images.githubusercontent.com/5040182/28214117-512b8350-68a9-11e7-90ed-1706c6eb9d5e.png)


I put an info block instead so the customer knows that the order is yet to be validated:
![image](https://user-images.githubusercontent.com/5040182/28214081-26d9370a-68a9-11e7-87bc-e1749a879be8.png)
