### PR TITLE
website_sale_require_legal: Fix rendering error when error list is empty

### DIFF
--- a/website_sale_require_legal/views/website_sale.xml
+++ b/website_sale_require_legal/views/website_sale.xml
@@ -4,7 +4,7 @@
 <odoo>
 
     <template id="accept_input">
-        <div t-attf-class="form-group col-md-12 #{'has-error' if error.get('accepted_legal_terms') else ''}">
+        <div t-attf-class="form-group col-md-12 #{'has-error' if error and error.get('accepted_legal_terms') else ''}">
             <label for="accepted_legal_terms" class="control-label">
                 <input
                     type="checkbox"


### PR DESCRIPTION
`if error.get(...)` should be `if error and error.get(..)` to avoid following rendering error :
```
QWebException: 'NoneType' object has no attribute 'get' Traceback (most recent call last): File "/opt/odoo/src/odoo/addons/base/ir/ir_qweb/qweb.py", line 315, in _compiled_fn return compiled(self, append, values, options, log) File "<template>", line 1, in template_website_sale_require_legal_accept_input_50 AttributeError: 'NoneType' object has no attribute 'get' Error to render compiling AST AttributeError: 'NoneType' object has no attribute 'get' Template: website_sale_require_legal.accept_input Path: /templates/t/div Node: <div t-attf-class="form-group col-md-12 #{'has-error' if error.get('accepted_legal_terms') else ''}"> <label for="accepted_legal_terms" class="control-label"> <input type="checkbox" name="accepted_legal_terms" id="accepted_legal_terms" required="required" data-oe-id="1617" data-oe-model="ir.ui.view" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]/label[1]/input[1]"/> <t t-call="website_legal_page.acceptance_full"/> </label> </div>
```